### PR TITLE
Add use of upload-release-asset GitHub Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push, pull_request]
+on: 
+  push:
+  pull_request:
+  release:
+    types: [published]
 
 jobs:
   build:
@@ -58,3 +62,20 @@ jobs:
       with:
         name: vcpkg-robotology
         path: C:/robotology/vcpkg
+        
+    - name: Prepare release file
+      if: github.event_name == 'release'
+      shell: cmd 
+      run: |
+        7z a vcpkg-robotology.zip C:\robotology
+        
+    - name: Upload Release Asset
+      if: github.event_name == 'release'
+      uses: actions/upload-release-asset@v1.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./vcpkg-robotology.zip
+          asset_name: vcpkg-robotology.zip
+          asset_content_type: application/zip


### PR DESCRIPTION
Via this GitHub Action, it is possible to automatically upload the archive that contains the generate vcpkg archive.

See actions/upload-release-asset#34 for details.

See https://github.com/iit-danieli-joint-lab/idjl-software-dependencies-vcpkg/pull/7 for a similar PR.