### PR TITLE
Add workaround for https://github.com/actions/virtual-environments/issues/605 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
       run: |
         choco install -y wget
         mkdir C:/robotology
+        cd C:/robotology
         # Download a custom vcpkg 2019.10 that already contains ace pre-compiled, as a workaround for https://github.com/actions/virtual-environments/issues/605
         wget https://github.com/robotology/robotology-vcpkg-binary-ports/releases/download/storage/robotology-vcpkg-2019.10-ace.zip
         7z x robotology-vcpkg-2019.10-ace.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,22 +19,6 @@ jobs:
       shell: bash 
       run: |
         df -h
-    
-    # Workaround for https://github.com/actions/virtual-environments/issues/326 until the fix is deployed
-    - name: Remove
-      shell: pwsh 
-      run: |
-        rm -Force -Recurse -Path 'C:\Program Files (x86)\Android'
-        rm -Force -Recurse -Path 'C:\Program Files\Java'
-        rm -Force -Recurse -Path 'C:\Program Files\dotnet'
-        rm -Force -Recurse -Path 'C:\Program Files (x86)\Google'
-        rm -Force -Recurse -Path 'C:\tools\php'
-        rm -Force -Recurse -Path 'C:\Rust'
-
-    - name: Check free space 
-      shell: bash 
-      run: |
-        df -h
   
     # Workaround for https://github.community/t5/GitHub-Actions/Windows-tests-worked-yesterday-broken-today/td-p/43574
     - name: Override bash shell PATH (windows-latest)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,15 @@ jobs:
     - name: Download custom vcpkg and additional ports 
       shell: bash
       run: |
+        choco install -y wget
         mkdir C:/robotology
-        git clone -b 2019.10 https://github.com/microsoft/vcpkg  C:/robotology/vcpkg
+        # Download a custom vcpkg 2019.10 that already contains ace pre-compiled, as a workaround for https://github.com/actions/virtual-environments/issues/605
+        wget https://github.com/robotology/robotology-vcpkg-binary-ports/releases/download/storage/robotology-vcpkg-2019.10-ace.zip
+        7z x robotology-vcpkg-2020.01-ace.zip
         C:/robotology/vcpkg/bootstrap-vcpkg.sh
         git clone https://github.com/robotology-dependencies/robotology-vcpkg-binary-ports C:/robotology-vcpkg-binary-ports
+        cd C:/robotology-vcpkg-binary-ports
+        git checkout v0.1.0
 
     - name: Install vcpkg ports
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         mkdir C:/robotology
         # Download a custom vcpkg 2019.10 that already contains ace pre-compiled, as a workaround for https://github.com/actions/virtual-environments/issues/605
         wget https://github.com/robotology/robotology-vcpkg-binary-ports/releases/download/storage/robotology-vcpkg-2019.10-ace.zip
-        7z x robotology-vcpkg-2020.01-ace.zip
+        7z x robotology-vcpkg-2019.10-ace.zip
         C:/robotology/vcpkg/bootstrap-vcpkg.sh
         git clone https://github.com/robotology-dependencies/robotology-vcpkg-binary-ports C:/robotology-vcpkg-binary-ports
         cd C:/robotology-vcpkg-binary-ports

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
         # Download a custom vcpkg 2019.10 that already contains ace pre-compiled, as a workaround for https://github.com/actions/virtual-environments/issues/605
         wget https://github.com/robotology/robotology-vcpkg-binary-ports/releases/download/storage/robotology-vcpkg-2019.10-ace.zip
         7z x robotology-vcpkg-2019.10-ace.zip
+        rm robotology-vcpkg-2019.10-ace.zip
         C:/robotology/vcpkg/bootstrap-vcpkg.sh
         git clone https://github.com/robotology-dependencies/robotology-vcpkg-binary-ports C:/robotology-vcpkg-binary-ports
         cd C:/robotology-vcpkg-binary-ports


### PR DESCRIPTION
Use a pre-compiled vcpkg 2019.10 installation with just ACE to bootstrap the compilation of the complete pre-compiled vcpkg archive, as a workaround for actions/virtual-environments#605 .

Furthermore, remove an old workaround for issue https://github.com/actions/virtual-environments/issues/326 .

Furthermore, to avoid regressions use a fixed release of robotology-vcpkg-binary-ports (in particular the v0.1.0).