### PR TITLE
Update vcpkg and robotology-vcpkg-binary-ports versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,11 +37,11 @@ jobs:
         cd C:/robotology/vcpkg
         # Update vcpkg to a newer commit
         git fetch
-        git checkout 5852144908b2c714be6f0d343f1de01ca2ec7758
+        git checkout 2020.06
         C:/robotology/vcpkg/bootstrap-vcpkg.sh
         git clone https://github.com/robotology-dependencies/robotology-vcpkg-binary-ports C:/robotology/robotology-vcpkg-binary-ports
         cd C:/robotology/robotology-vcpkg-binary-ports
-        git checkout v0.1.0
+        git checkout v0.1.1
 
     - name: Install vcpkg ports
       shell: bash

--- a/gazebo-repos.yaml
+++ b/gazebo-repos.yaml
@@ -2,7 +2,11 @@ repositories:
   gazebo:
     type: git
     url: https://github.com/traversaro/gazebo
-    version: 4ada2574f0735f6fdc933b6bc7e104b00e50e25e
+    # Commit from https://github.com/traversaro/gazebo/tree/fix-vcpkg-gha
+    # With backport of:
+    #  * https://github.com/osrf/gazebo/pull/2758
+    #  * https://github.com/osrf/gazebo/pull/2719
+    version: bc4c1714975433c39acda779d19a2e284ed01fc4
   gts:
     type: git
     url: https://github.com/finetjul/gts
@@ -34,4 +38,4 @@ repositories:
   sdformat:
     type: git
     url: https://github.com/osrf/sdformat
-    version: f7dcdd74fb900e79d5d12db4e022f6e9c83831a1
+    version: b6f73d9fe0e55c9933b1d369dda2771e14ec6ef9


### PR DESCRIPTION
Bump:
* vcpkg to 2020.06 tag
* robotology-vcpkg-binary-ports  to v0.1.1 tag (to include https://github.com/robotology/robotology-vcpkg-binary-ports/pull/10)

Furthermore, as Gazebo has a problem with the latest version of Boost that is  shipping with vcpkg, change the version of Gazebo compiled to include a fix for it ( backport of https://github.com/osrf/gazebo/pull/2758 ).

I had to bump vcpkg version because the old version used had some problem with downloading dependencies from MSYS2 (see for example https://github.com/robotology/robotology-superbuild-dependencies-vcpkg/actions/runs/168329220).