### PR TITLE
Cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,13 +30,8 @@ jobs:
         choco install -y wget
         mkdir C:/robotology
         cd C:/robotology
-        # Download a custom vcpkg 2019.10 that already contains ace pre-compiled, as a workaround for https://github.com/actions/virtual-environments/issues/605
-        wget https://github.com/robotology/robotology-vcpkg-binary-ports/releases/download/storage/robotology-vcpkg-2019.10-ace.zip
-        7z x robotology-vcpkg-2019.10-ace.zip
-        rm robotology-vcpkg-2019.10-ace.zip
-        cd C:/robotology/vcpkg
-        # Update vcpkg to a newer commit
-        git fetch
+        git clone https://github.com/Microsoft/vcpkg
+        cd vcpkg
         git checkout 76a7e9248fb3c57350b559966dcaa2d52a5e4458
         C:/robotology/vcpkg/bootstrap-vcpkg.sh
         git clone https://github.com/robotology/robotology-vcpkg-ports C:/robotology/robotology-vcpkg-ports

--- a/README.md
+++ b/README.md
@@ -49,14 +49,6 @@ As Gazebo on Windows does not provide the single `gazebo` executable available i
 ### Install or remove vcpkg ports 
 You can install or remove  ports from the vcpkg installation in `C:/robotology/vcpkg` as you do for any other vcpkg installation.
 
-However, as this  vcpkg installation contains some ports installed  from the custom port repo contained in `C:/robotology/vcpkg`, 
-due to a regression in vcpkg (see https://github.com/microsoft/vcpkg/issues/10119) you need to pass the `--overlay-ports=C:/robotology/robotology-vcpkg-binary-ports` argument whenever you use vcpkg.
-
-For example, to install a new port called `<portname>` the correct command is:
-~~~
-./vcpkg.exe install --overlay-ports=C:/robotology/robotology-vcpkg-binary-ports <portname>:x64-windows
-~~~
-
 ### GitHub Actions 
 To use the script in a GitHub Action script, you can use the following snippet: 
 ~~~~


### PR DESCRIPTION
* Remove references to the need to specify overlay-ports: As https://github.com/microsoft/vcpkg/issues/10119 has been solved, there is no need to specify overlay-ports every time.
* Remove ACE workaround: As the ace failure in vcpkg was fixed (see https://github.com/microsoft/vcpkg/pull/11369), we can now remove the use of an already compiled ace to bootstrap the process 
