### PR TITLE
Gazebo-related cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,8 +110,7 @@ jobs:
       shell: bash
       run: |
         # Install dependencies for gazebo11 and related ignition dependencies (listed in https://github.com/ignition-tooling/gazebodistro/blob/master/gazebo11.yaml)         
-        # gts is not present due to https://github.com/microsoft/vcpkg/issues/10422, and its dependency glib is present instead
-        C:/robotology/vcpkg/vcpkg.exe --overlay-ports=C:/robotology/robotology-vcpkg-ports --overlay-ports=${GITHUB_WORKSPACE}/custom-ports install --triplet x64-windows boost-asio boost-any boost-date-time boost-filesystem boost-format boost-interprocess boost-iostreams boost-program-options boost-property-tree boost-regex boost-smart-ptr boost-system boost-thread boost-variant boost-uuid bullet3 cppzmq curl dlfcn-win32 freeimage glib libyaml libzip jsoncpp ogre protobuf qt5-base qwt sqlite3[core,tool] tbb tinyxml tinyxml2 urdfdom zeromq
+        C:/robotology/vcpkg/vcpkg.exe --overlay-ports=C:/robotology/robotology-vcpkg-ports --overlay-ports=${GITHUB_WORKSPACE}/custom-ports install --triplet x64-windows boost-asio boost-any boost-date-time boost-filesystem boost-format boost-interprocess boost-iostreams boost-program-options boost-property-tree boost-regex boost-smart-ptr boost-system boost-thread boost-variant boost-uuid bullet3 cppzmq curl dlfcn-win32 freeimage gts libyaml libzip jsoncpp ogre protobuf qt5-base qwt sqlite3[core,tool] tbb tinyxml tinyxml2 urdfdom zeromq
         
     # Remove temporary files https://github.com/Microsoft/vcpkg/blob/master/docs/about/faq.md#how-can-i-remove-temporary-files
     # For some reason doing using git bash to do rm -rf fails for icu's port buildtrees, probably for the use of msys2 

--- a/gazebo-repos.yaml
+++ b/gazebo-repos.yaml
@@ -1,41 +1,33 @@
 repositories:
   gazebo:
     type: git
-    url: https://github.com/traversaro/gazebo
-    # Commit from https://github.com/traversaro/gazebo/tree/fix-vcpkg-gha
-    # With backport of:
-    #  * https://github.com/osrf/gazebo/pull/2758
-    #  * https://github.com/osrf/gazebo/pull/2719
-    version: bc4c1714975433c39acda779d19a2e284ed01fc4
-  gts:
-    type: git
-    url: https://github.com/finetjul/gts
-    version: c4da61ae075f355d9ecc9f2d4767acf777f54c2b
+    url: https://github.com/osrf/gazebo
+    version: gazebo11_11.2.0
   ign-cmake:
     type: git
     url: https://github.com/ignitionrobotics/ign-cmake
-    version: 2f5c3178dbee496beedf8e4a636a2c71219fe8e0
+    version: ignition-cmake2_2.5.0
   ign-common:
     type: git
     url: https://github.com/ignitionrobotics/ign-common
-    version: 70658d137256dd57e87690ff45bd3c077c087f09
+    version: ignition-common3_3.6.1
   ign-fuel-tools:
     type: git
     url: https://github.com/ignitionrobotics/ign-fuel-tools
-    version: af1eec41c92cdc9b26b9d03b084b7aeb3ca1fb9e
+    version: ignition-fuel-tools4_4.2.1
   ign-math:
     type: git
     url: https://github.com/ignitionrobotics/ign-math
-    version: c2726425418f93a0ea384815c7eab55749a7d0ea
+    version: ignition-math6_6.6.0
   ign-msgs:
     type: git
     url: https://github.com/ignitionrobotics/ign-msgs
-    version: 84ff940249ce23a62917d8ca239f79450548d0a0
+    version: ignition-msgs5_5.3.0
   ign-transport:
     type: git
     url: https://github.com/ignitionrobotics/ign-transport
-    version: 185edc9ce3c5254b1b57aa4b87af5f6c474ce097
+    version: ignition-transport8_8.1.0
   sdformat:
     type: git
     url: https://github.com/osrf/sdformat
-    version: b6f73d9fe0e55c9933b1d369dda2771e14ec6ef9
+    version: sdformat9_9.3.0


### PR DESCRIPTION
* Install directly gts from vcpkg as a Gazebo dependency, https://github.com/microsoft/vcpkg/issues/10422 was fixed.
* Gazebo and Ignition dependencies: use released version, see https://github.com/robotology/robotology-superbuild-dependencies-vcpkg/issues/26 .