### PR TITLE
Bump vcpkg tag and remove pdb files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         cd C:/robotology
         git clone https://github.com/Microsoft/vcpkg
         cd vcpkg
-        git checkout 70f192e073dd9e5ed503fc1e86d8a54e2fbaceb4
+        git checkout ac2ddd5f059b56b6e0b9fc0c73bd4feccad539ff
         C:/robotology/vcpkg/bootstrap-vcpkg.sh
         git clone https://github.com/robotology/robotology-vcpkg-ports C:/robotology/robotology-vcpkg-ports
         cd C:/robotology/robotology-vcpkg-ports
@@ -53,6 +53,13 @@ jobs:
         RMDIR /Q/S C:\robotology\vcpkg\buildtrees
         RMDIR /Q/S C:\robotology\vcpkg\packages
         RMDIR /Q/S C:\robotology\vcpkg\downloads
+    
+    # Remove .pdb (i.e. debug symbols) files to save space
+    - name: Remove .pdb
+      shell: bash
+      run: |
+        rm -rf /c/robotology/vcpkg/installed/x64-windows/bin/*.pdb
+        rm -rf /c/robotology/vcpkg/installed/x64-windows/debug/bin/*.pdb
     
     - name: Install setup scripts    
       shell: bash
@@ -123,6 +130,14 @@ jobs:
         RMDIR /Q/S C:\robotology\vcpkg\packages
         RMDIR /Q/S C:\robotology\vcpkg\downloads
         
+    # Remove .pdb (i.e. debug symbols) files to save space
+    - name: Remove .pdb
+      shell: bash
+      run: |
+        rm -rf /c/robotology/vcpkg/installed/x64-windows/bin/*.pdb
+        rm -rf /c/robotology/vcpkg/installed/x64-windows/debug/bin/*.pdb
+      
+  
     - uses: actions/upload-artifact@v1
       with:
         name: vcpkg-robotology-with-gazebo-deps

--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ As Gazebo on Windows does not provide the single `gazebo` executable available i
 ### Install or remove vcpkg ports 
 You can install or remove  ports from the vcpkg installation in `C:/robotology/vcpkg` as you do for any other vcpkg installation.
 
+### pdb files
+To reduce the size of the pre-compiled archives, the .pdb files (see https://stackoverflow.com/questions/3899573/what-is-a-pdb-file) 
+that contain the debug symbols of the provided library are removed from both the Release and Debug version of the vcpkg-installed libraries.
+If you need to have the debug symbols of the vcpkg-installed libraries, it is suggested to install the vcpkg ports directly without 
+relying on the pre-compiled archive provided by this repo. 
+
 ### GitHub Actions 
 To use the script in a GitHub Action script, you can use the following snippet: 
 ~~~~


### PR DESCRIPTION
Fix https://github.com/robotology/robotology-superbuild-dependencies-vcpkg/issues/34 
Fix https://github.com/robotology/robotology-superbuild-dependencies-vcpkg/issues/33 

For what regards .pdb files, apparently there is low interested in their use, so that it make sense to just remove them without the additional effort to preparing some `debug` package to contain just the .pdb files. Users interested in them are recommended to build the vcpkg dependencies on their own. The README has been updated in https://github.com/robotology/robotology-superbuild-dependencies-vcpkg/commit/348ff05490c3c8963ad98a08e6a58812fd8aafea .