### PR TITLE
Also set CMAKE_LIBRARY_PATH to ensure that vcpkg libraries installed in lib/manual-link are correctly found even without CMAKE_TOOLCHAIN_FILE

### DIFF
--- a/scripts/addPathsToUserEnvVariables-vcpkg.ps1
+++ b/scripts/addPathsToUserEnvVariables-vcpkg.ps1
@@ -38,5 +38,9 @@ Add-ValueToUserEnvVariable PATH ($VcpkgInstallDir + "\debug\bin");
 Add-ValueToUserEnvVariable CMAKE_PREFIX_PATH ($VcpkgInstallDir);
 Add-ValueToUserEnvVariable CMAKE_PREFIX_PATH ($VcpkgInstallDir + "\debug");
 
+# Extend CMAKE_LIBRARY_PATH
+Add-ValueToUserEnvVariable CMAKE_LIBRARY_PATH ($VcpkgInstallDir + "\lib\manual-link");
+Add-ValueToUserEnvVariable CMAKE_LIBRARY_PATH ($VcpkgInstallDir + "\debug\lib\manual-link");
+
 # Extend CMAKE_PROGRAM_TOOLS (for protobuf)
 Add-ValueToUserEnvVariable CMAKE_PROGRAM_PATH ($VcpkgInstallDir + "\tools\protobuf");

--- a/scripts/removePathsFromUserEnvVariables-vcpkg.ps1
+++ b/scripts/removePathsFromUserEnvVariables-vcpkg.ps1
@@ -36,6 +36,10 @@ Remove-ValueFromUserEnvVariable PATH ($VcpkgInstallDir + "\debug\bin");
 Remove-ValueFromUserEnvVariable CMAKE_PREFIX_PATH ($VcpkgInstallDir);
 Remove-ValueFromUserEnvVariable CMAKE_PREFIX_PATH ($VcpkgInstallDir + "\debug");
 
+# Cleanup CMAKE_LIBRARY_PATH
+Remove-ValueFromUserEnvVariable CMAKE_LIBRARY_PATH ($VcpkgInstallDir + "\lib\manual-link");
+Remove-ValueFromUserEnvVariable CMAKE_LIBRARY_PATH ($VcpkgInstallDir + "\debug\lib\manual-link");
+
 # Cleanup CMAKE_PROGRAM_PATH
 Remove-ValueFromUserEnvVariable CMAKE_PROGRAM_PATH ($VcpkgInstallDir + "\tools\protobuf");
 

--- a/scripts/setup-vcpkg.bat
+++ b/scripts/setup-vcpkg.bat
@@ -15,5 +15,9 @@ rem Update CMAKE_PREFIX_PATH
 set "CMAKE_PREFIX_PATH=%CMAKE_PREFIX_PATH%;%vcpkgInstallDir%"
 set "CMAKE_PREFIX_PATH=%CMAKE_PREFIX_PATH%;%vcpkgInstallDir%\debug"
 
+rem Update CMAKE_LIBRARY_PATH
+set "CMAKE_LIBRARY_PATH=%CMAKE_LIBRARY_PATH%;%vcpkgInstallDir%\lib\manual-link"
+set "CMAKE_LIBRARY_PATH=%CMAKE_LIBRARY_PATH%;%vcpkgInstallDir%\debug\lib\manual-link"
+
 rem Update CMAKE_PROGRAM_PATH
 set "CMAKE_PROGRAM_PATH=%CMAKE_PROGRAM_PATH%;%vcpkgInstallDir%\tools\protobuf"

--- a/scripts/setup-vcpkg.sh
+++ b/scripts/setup-vcpkg.sh
@@ -14,5 +14,9 @@ export PATH=$PATH:${vcpkgInstallDir}/debug/bin
 export CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH:+${CMAKE_PREFIX_PATH}:}${vcpkgInstallDir}
 export CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH:+${CMAKE_PREFIX_PATH}:}${vcpkgInstallDir}/debug
 
+# Update CMAKE_LIBRARY_PATH
+export CMAKE_LIBRARY_PATH=${CMAKE_LIBRARY_PATH:+${CMAKE_LIBRARY_PATH}:}${vcpkgInstallDir}/lib/manual-link
+export CMAKE_LIBRARY_PATH=${CMAKE_LIBRARY_PATH:+${CMAKE_LIBRARY_PATH}:}${vcpkgInstallDir}/debug/lib/manual-link
+
 # Update CMAKE_PROGRAM_TOOLS (for protobuf)
 export CMAKE_PROGRAM_PATH=${CMAKE_PROGRAM_PATH:+${CMAKE_PROGRAM_PATH}:}${vcpkgInstallDir}/tools/protobuf


### PR DESCRIPTION
Fix https://github.com/robotology/robotology-superbuild/issues/602 .