### PR TITLE
Add nlohmann-json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
     - name: Install vcpkg ports
       shell: bash
       run: |
-        C:/robotology/vcpkg/vcpkg.exe --overlay-ports=C:/robotology/robotology-vcpkg-ports --overlay-ports=${GITHUB_WORKSPACE}/custom-ports install --triplet x64-windows asio boost-circular-buffer boost-asio boost-bind boost-process boost-dll boost-filesystem boost-system freeglut esdcan-binary glew glfw3 ode openssl libxml2 matio ipopt-binary cppad irrlicht spdlog
+        C:/robotology/vcpkg/vcpkg.exe --overlay-ports=C:/robotology/robotology-vcpkg-ports --overlay-ports=${GITHUB_WORKSPACE}/custom-ports install --triplet x64-windows asio boost-circular-buffer boost-asio boost-bind boost-process boost-dll boost-filesystem boost-system freeglut esdcan-binary glew glfw3 nlohmann-json ode openssl libxml2 matio ipopt-binary cppad irrlicht spdlog
         C:/robotology/vcpkg/vcpkg.exe list
 
     # Remove temporary files https://github.com/Microsoft/vcpkg/blob/master/docs/about/faq.md#how-can-i-remove-temporary-files


### PR DESCRIPTION
Used in yarp-telemetry (not now as the required version is to recent, but in the future) and in bipedal-locomotion-framework (see https://github.com/dic-iit/bipedal-locomotion-framework/pull/316 and https://github.com/robotology/robotology-superbuild/issues/763).