### PR TITLE
Add PCL visualization feature and fix build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,11 @@ jobs:
     - name: Download custom vcpkg and additional ports
       shell: bash
       run: |
+        # Print environment variables for debug
+        env
+        # Avoid conflicts with vcpkg in C:\vcpkg
+        rm -rf C:/vcpkg
+        echo "VCPKG_ROOT=C:/robotology/vcpkg" >> $GITHUB_ENV
         choco install -y wget
         mkdir C:/robotology
         cd C:/robotology

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,7 +188,7 @@ jobs:
       shell: bash
       run: |
         # Install dependencies for gazebo11
-        C:/robotology/vcpkg/vcpkg.exe --overlay-ports=C:/robotology/robotology-vcpkg-ports --overlay-ports=${GITHUB_WORKSPACE}/custom-ports install --triplet x64-windows boost-circular-buffer boost-asio boost-any boost-date-time boost-filesystem boost-format boost-interprocess boost-iostreams boost-program-options boost-property-tree boost-regex boost-smart-ptr boost-system boost-thread boost-variant boost-uuid bullet3 cppzmq curl dlfcn-win32 freeimage gts libyaml libzip jsoncpp ogre[core,assimp,freeimage,overlay,zziplib] protobuf qt5-base qwt sqlite3[core,tool] tbb tinyxml2 urdfdom zeromq ignition-cmake2 ignition-common3 ignition-fuel-tools4 ignition-math6 ignition-msgs5 ignition-transport8 sdformat9 pcl
+        C:/robotology/vcpkg/vcpkg.exe --overlay-ports=C:/robotology/robotology-vcpkg-ports --overlay-ports=${GITHUB_WORKSPACE}/custom-ports install --triplet x64-windows boost-circular-buffer boost-asio boost-any boost-date-time boost-filesystem boost-format boost-interprocess boost-iostreams boost-program-options boost-property-tree boost-regex boost-smart-ptr boost-system boost-thread boost-variant boost-uuid bullet3 cppzmq curl dlfcn-win32 freeimage gts libyaml libzip jsoncpp ogre[core,assimp,freeimage,overlay,zziplib] protobuf qt5-base qwt sqlite3[core,tool] tbb tinyxml2 urdfdom zeromq ignition-cmake2 ignition-common3 ignition-fuel-tools4 ignition-math6 ignition-msgs5 ignition-transport8 sdformat9 pcl[visualization] vtk
         C:/robotology/vcpkg/vcpkg.exe list
 
     # Remove temporary files https://github.com/Microsoft/vcpkg/blob/master/docs/about/faq.md#how-can-i-remove-temporary-files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,8 @@ jobs:
     - name: Install vcpkg ports
       shell: bash
       run: |
+        # Avoid conflicts with vcpkg in C:\vcpkg
+        echo "VCPKG_ROOT=C:/robotology/vcpkg" >> $GITHUB_ENV
         C:/robotology/vcpkg/vcpkg.exe --overlay-ports=C:/robotology/robotology-vcpkg-ports --overlay-ports=${GITHUB_WORKSPACE}/custom-ports install --triplet x64-windows asio assimp boost-circular-buffer boost-asio boost-bind boost-process boost-dll boost-filesystem boost-system freeglut esdcan-binary glew glfw3 nlohmann-json ode openssl libxml2 matio ipopt-binary cppad irrlicht spdlog
         C:/robotology/vcpkg/vcpkg.exe list
 
@@ -192,6 +194,8 @@ jobs:
     - name: Install vcpkg ports
       shell: bash
       run: |
+        # Avoid conflicts with vcpkg in C:\vcpkg
+        echo "VCPKG_ROOT=C:/robotology/vcpkg" >> $GITHUB_ENV
         # Install dependencies for gazebo11
         C:/robotology/vcpkg/vcpkg.exe --overlay-ports=C:/robotology/robotology-vcpkg-ports --overlay-ports=${GITHUB_WORKSPACE}/custom-ports install --triplet x64-windows boost-circular-buffer boost-asio boost-any boost-date-time boost-filesystem boost-format boost-interprocess boost-iostreams boost-program-options boost-property-tree boost-regex boost-smart-ptr boost-system boost-thread boost-variant boost-uuid bullet3 cppzmq curl dlfcn-win32 freeimage gts libyaml libzip jsoncpp ogre[core,assimp,freeimage,overlay,zziplib] protobuf qt5-base qwt sqlite3[core,tool] tbb tinyxml2 urdfdom zeromq ignition-cmake2 ignition-common3 ignition-fuel-tools4 ignition-math6 ignition-msgs5 ignition-transport8 sdformat9 pcl[visualization] vtk
         C:/robotology/vcpkg/vcpkg.exe list
@@ -253,6 +257,8 @@ jobs:
     - name: Download Gazebo and related libraries
       shell: bash
       run: |
+        # Avoid conflicts with vcpkg in C:\vcpkg
+        echo "VCPKG_ROOT=C:/robotology/vcpkg" >> $GITHUB_ENV
         mkdir C:/robotology/gazebo
         cd C:/robotology/gazebo
         mkdir src

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Override bash shell PATH (windows-latest)
       run: echo "C:\Program Files\Git\bin" >> $GITHUB_PATH
 
-    - name: Download custom vcpkg and additional ports
+    - name: Avoid conflicts with vcpkg in C:\vcpkg
       shell: bash
       run: |
         # Print environment variables for debug
@@ -34,6 +34,10 @@ jobs:
         # Avoid conflicts with vcpkg in C:\vcpkg
         rm -rf C:/vcpkg
         echo "VCPKG_ROOT=C:/robotology/vcpkg" >> $GITHUB_ENV
+
+    - name: Download custom vcpkg and additional ports
+      shell: bash
+      run: |
         choco install -y wget
         mkdir C:/robotology
         cd C:/robotology
@@ -124,11 +128,18 @@ jobs:
       run: |
         df -h
 
+    - name: Avoid conflicts with vcpkg in C:\vcpkg
+      shell: bash
+      run: |
+        # Print environment variables for debug
+        env
+        # Avoid conflicts with vcpkg in C:\vcpkg
+        rm -rf C:/vcpkg
+        echo "VCPKG_ROOT=C:/robotology/vcpkg" >> $GITHUB_ENV
+
     - name: Install vcpkg ports
       shell: bash
       run: |
-        # Avoid conflicts with vcpkg in C:\vcpkg
-        echo "VCPKG_ROOT=C:/robotology/vcpkg" >> $GITHUB_ENV
         C:/robotology/vcpkg/vcpkg.exe --overlay-ports=C:/robotology/robotology-vcpkg-ports --overlay-ports=${GITHUB_WORKSPACE}/custom-ports install --triplet x64-windows asio assimp boost-circular-buffer boost-asio boost-bind boost-process boost-dll boost-filesystem boost-system freeglut esdcan-binary glew glfw3 nlohmann-json ode openssl libxml2 matio ipopt-binary cppad irrlicht spdlog
         C:/robotology/vcpkg/vcpkg.exe list
 
@@ -191,11 +202,18 @@ jobs:
       run: |
         df -h
 
+    - name: Avoid conflicts with vcpkg in C:\vcpkg
+      shell: bash
+      run: |
+        # Print environment variables for debug
+        env
+        # Avoid conflicts with vcpkg in C:\vcpkg
+        rm -rf C:/vcpkg
+        echo "VCPKG_ROOT=C:/robotology/vcpkg" >> $GITHUB_ENV
+
     - name: Install vcpkg ports
       shell: bash
       run: |
-        # Avoid conflicts with vcpkg in C:\vcpkg
-        echo "VCPKG_ROOT=C:/robotology/vcpkg" >> $GITHUB_ENV
         # Install dependencies for gazebo11
         C:/robotology/vcpkg/vcpkg.exe --overlay-ports=C:/robotology/robotology-vcpkg-ports --overlay-ports=${GITHUB_WORKSPACE}/custom-ports install --triplet x64-windows boost-circular-buffer boost-asio boost-any boost-date-time boost-filesystem boost-format boost-interprocess boost-iostreams boost-program-options boost-property-tree boost-regex boost-smart-ptr boost-system boost-thread boost-variant boost-uuid bullet3 cppzmq curl dlfcn-win32 freeimage gts libyaml libzip jsoncpp ogre[core,assimp,freeimage,overlay,zziplib] protobuf qt5-base qwt sqlite3[core,tool] tbb tinyxml2 urdfdom zeromq ignition-cmake2 ignition-common3 ignition-fuel-tools4 ignition-math6 ignition-msgs5 ignition-transport8 sdformat9 pcl[visualization] vtk
         C:/robotology/vcpkg/vcpkg.exe list
@@ -253,12 +271,19 @@ jobs:
       run: |
         pip install vcstool colcon-common-extensions
 
+    - name: Avoid conflicts with vcpkg in C:\vcpkg
+      shell: bash
+      run: |
+        # Print environment variables for debug
+        env
+        # Avoid conflicts with vcpkg in C:\vcpkg
+        rm -rf C:/vcpkg
+        echo "VCPKG_ROOT=C:/robotology/vcpkg" >> $GITHUB_ENV
+
     # Based on https://colcon.readthedocs.io/en/released/user/quick-start.html#build-gazebo-and-the-ignition-packages
     - name: Download Gazebo and related libraries
       shell: bash
       run: |
-        # Avoid conflicts with vcpkg in C:\vcpkg
-        echo "VCPKG_ROOT=C:/robotology/vcpkg" >> $GITHUB_ENV
         mkdir C:/robotology/gazebo
         cd C:/robotology/gazebo
         mkdir src


### PR DESCRIPTION
10 days ago https://github.com/robotology/robotology-superbuild-dependencies-vcpkg/pull/53 was passing, but after merge the CI is not working, see https://github.com/robotology/robotology-superbuild-dependencies-vcpkg/actions/runs/3046391517/jobs/4909144670 : 

~~~
2022-09-13T19:15:52.2974487Z ##[group]Run RMDIR /Q/S C:\robotology\vcpkg\buildtrees
2022-09-13T19:15:52.2975160Z [36;1mRMDIR /Q/S C:\robotology\vcpkg\buildtrees[0m
2022-09-13T19:15:52.2975548Z [36;1mRMDIR /Q/S C:\robotology\vcpkg\packages[0m
2022-09-13T19:15:52.2975890Z [36;1mRMDIR /Q/S C:\robotology\vcpkg\downloads[0m
2022-09-13T19:15:52.3023313Z shell: C:\Windows\system32\cmd.EXE /D /E:ON /V:OFF /S /C "CALL "{0}""
2022-09-13T19:15:52.3023651Z ##[endgroup]
2022-09-13T19:15:52.3208009Z The system cannot find the file specified.
2022-09-13T19:15:52.3213681Z The system cannot find the file specified.
2022-09-13T19:15:52.3217317Z The system cannot find the file specified.
2022-09-13T19:15:52.3285558Z ##[error]Process completed with exit code 2. 
~~~
