### PR TITLE
Explicitly install opencv[contrib]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
     - name: Install vcpkg ports
       shell: bash
       run: |
-        C:/robotology/vcpkg/vcpkg.exe --overlay-ports=C:/robotology/robotology-vcpkg-ports --overlay-ports=${GITHUB_WORKSPACE}/custom-ports install --triplet x64-windows ace eigen3 graphviz gsl libjpeg-turbo opencv portaudio sdl1 sdl2 qt5-base[latest] qt5-declarative qt5-multimedia qt5-quickcontrols qt5-quickcontrols2 sqlite3[core,tool] tinyxml
+        C:/robotology/vcpkg/vcpkg.exe --overlay-ports=C:/robotology/robotology-vcpkg-ports --overlay-ports=${GITHUB_WORKSPACE}/custom-ports install --triplet x64-windows ace eigen3 graphviz gsl libjpeg-turbo opencv[contrib] portaudio sdl1 sdl2 qt5-base[latest] qt5-declarative qt5-multimedia qt5-quickcontrols qt5-quickcontrols2 sqlite3[core,tool] tinyxml
         C:/robotology/vcpkg/vcpkg.exe list
 
     # Remove temporary files https://github.com/Microsoft/vcpkg/blob/master/docs/about/faq.md#how-can-i-remove-temporary-files


### PR DESCRIPTION
In past version of [robotology-superbuild-dependencies-vcpkg](https://github.com/robotology/robotology-superbuild-dependencies-vcpkg), it seems that `opencv[contrib]` was installed, while in 0.10.0 it is not . As several software packages rely on the aruco functionalities contained in `opencv[contrib]` it is a good idea to install it.