### PR TITLE
Upgrade CI to Windows 2022 and vcpkg version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,8 @@ jobs:
         cd C:/robotology
         git clone https://github.com/Microsoft/vcpkg
         cd vcpkg
-        git checkout 2025.10.17
+        # Keeping this hash until https://github.com/microsoft/vcpkg/pull/49103 is not released
+        git checkout c93431c51b046bd9f74356e8ac6cbf10586f7310
         C:/robotology/vcpkg/bootstrap-vcpkg.sh
         git clone https://github.com/robotology/robotology-vcpkg-ports C:/robotology/robotology-vcpkg-ports
         cd C:/robotology/robotology-vcpkg-ports

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         cd C:/robotology
         git clone https://github.com/Microsoft/vcpkg
         cd vcpkg
-        git checkout 2025.12.12
+        git checkout 2025.10.17
         C:/robotology/vcpkg/bootstrap-vcpkg.sh
         git clone https://github.com/robotology/robotology-vcpkg-ports C:/robotology/robotology-vcpkg-ports
         cd C:/robotology/robotology-vcpkg-ports

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,7 @@ on:
 
 jobs:
   build-yarp-deps-only:
-    # We would like to build with v140 toolset to be compatible with both VS2017, 2019
-    # But that will only be avaiilable in late november: https://github.com/actions/virtual-environments/issues/68
-    runs-on: windows-2019
+    runs-on: windows-2022
 
     steps:
     - uses: actions/checkout@v4
@@ -43,7 +41,7 @@ jobs:
         cd C:/robotology
         git clone https://github.com/Microsoft/vcpkg
         cd vcpkg
-        git checkout 2025.01.13
+        git checkout 2025.12.12
         C:/robotology/vcpkg/bootstrap-vcpkg.sh
         git clone https://github.com/robotology/robotology-vcpkg-ports C:/robotology/robotology-vcpkg-ports
         cd C:/robotology/robotology-vcpkg-ports
@@ -108,7 +106,7 @@ jobs:
 
 
   build:
-    runs-on: windows-2019
+    runs-on: windows-2022
     needs: build-yarp-deps-only
 
     steps:


### PR DESCRIPTION
Updated the CI workflow to use Windows 2022 and updated vcpkg checkout version.

The CI is failing:
- https://github.com/robotology/robotology-superbuild-dependencies-vcpkg/actions/runs/20914048135/job/60083190514

@traversaro updating vcpkg would fix it?